### PR TITLE
Add MapFish Print 3 Docker example

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,2 @@
+FROM camptocamp/mapfish_print:3
+COPY print-apps /usr/local/tomcat/webapps/ROOT/print-apps

--- a/README.md
+++ b/README.md
@@ -1,1 +1,33 @@
-placeholder for testing
+# MapFish Print Hello World
+
+This repository contains a minimal MapFish Print 3 configuration and a Dockerfile to run it.
+
+## Build the image
+
+```
+docker build -t mapfish-print .
+```
+
+## Run the container
+
+```
+docker run --rm -p 8080:8080 mapfish-print
+```
+
+The service will be available at `http://localhost:8080`.
+
+## Generate a sample map
+
+Send the provided print specification to the running container:
+
+```
+curl -X POST -H "Content-Type: application/json" --data @spec.json http://localhost:8080/print/print.pdf -o map.pdf
+```
+
+The request uses the configuration in `print-apps/`. The map is centered on Siegen, Germany and renders tiles from the basemap.de WMTS service published by the Federal Agency for Cartography and Geodesy (BKG):
+
+```
+https://sgx.geodatenzentrum.de/wmts_basemapde/1.0.0/WMTSCapabilities.xml
+```
+
+It returns the resulting map as `map.pdf`.

--- a/print-apps/config.yaml
+++ b/print-apps/config.yaml
@@ -1,0 +1,15 @@
+templates:
+  main:
+    attributes:
+      title:
+        type: string
+        default: "Hello Map"
+      map:
+        type: map
+        width: 500
+        height: 400
+        dpi: 72
+        projection: EPSG:25832
+    processors:
+      - !reportBuilder
+        template: main.jrxml

--- a/print-apps/main.jrxml
+++ b/print-apps/main.jrxml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="simple" pageWidth="595" pageHeight="842" columnWidth="555" leftMargin="20" rightMargin="20" topMargin="20" bottomMargin="20">
+    <parameter name="map" class="java.awt.Image"/>
+    <parameter name="title" class="java.lang.String"/>
+    <title>
+        <band height="50">
+            <textField>
+                <reportElement x="0" y="0" width="555" height="50"/>
+                <textFieldExpression><![CDATA[$P{title}]]></textFieldExpression>
+            </textField>
+        </band>
+    </title>
+    <detail>
+        <band height="792">
+            <image>
+                <reportElement x="0" y="0" width="555" height="792"/>
+                <imageExpression><![CDATA[$P{map}]]></imageExpression>
+            </image>
+        </band>
+    </detail>
+</jasperReport>

--- a/spec.json
+++ b/spec.json
@@ -1,0 +1,24 @@
+{
+  "layout": "main",
+  "outputFormat": "pdf",
+  "attributes": {
+    "title": "Hello world map",
+    "map": {
+      "projection": "EPSG:25832",
+      "center": [431350.93, 5636266.83],
+      "scale": 5000,
+      "dpi": 72,
+      "layers": [
+        {
+          "type": "wmts",
+          "baseURL": "https://sgx.geodatenzentrum.de/wmts_basemapde/tile/1.0.0/",
+          "layer": "de_basemapde_web_raster",
+          "matrixSet": "EPSG:25832",
+          "format": "image/png",
+          "style": "default",
+          "requestEncoding": "REST"
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add Dockerfile using MapFish Print 3 image
- include simple print configuration and Jasper template
- document build and usage with sample spec
- switch sample spec to basemap.de WMTS centered on Siegen

## Testing
- `docker --version` *(fails: command not found)*
- `docker build -t mapfish-print .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ad7824b71c8320a50bd553e8f1c7db